### PR TITLE
Update google-places/retrieving.md to reflect `GoogleApi` changes

### DIFF
--- a/content/books/airport-explorer/google-places/retrieving.md
+++ b/content/books/airport-explorer/google-places/retrieving.md
@@ -123,9 +123,9 @@ public class IndexModel : PageModel
                 MaxWidth = 400
             });
 
-            if (photosResponse.PhotoBuffer != null)
+            if (photosResponse.Buffer != null)
             {
-                airportDetail.Photo = Convert.ToBase64String(photosResponse.PhotoBuffer);
+                airportDetail.Photo = Convert.ToBase64String(photosResponse.Buffer);
                 airportDetail.PhotoCredit = photoCredit;
             }
         }


### PR DESCRIPTION
In https://github.com/vivet/GoogleApi/commit/79cd8a443820b6baa9fa3a8d44ecb3c486f07c67#diff-2bf0daea923ee7e8cd7d5875dc5fb466 PlacesPhotosResponse changed. It now:

- no longer has a `PhotoBuffer` property
- inherits from BaseStreamResponse which has a `Buffer` property

Fixes https://github.com/jerriep/airport-explorer-source/issues/3.